### PR TITLE
use posix compliant test for shell evaluation

### DIFF
--- a/functions/cmd_to_container.sh
+++ b/functions/cmd_to_container.sh
@@ -156,7 +156,7 @@ container_shell_or_logs(){
             2)
                 clear -x
                 title
-                if ! k3s crictl exec -it "$container_id" sh -c '[[ -e /bin/bash ]] && exec /bin/bash || exec /bin/sh'; then
+                if ! k3s crictl exec -it "$container_id" sh -c '[ -e /bin/bash ] && exec /bin/bash || exec /bin/sh'; then
                     echo -e "${red}This container does not accept shell access, try a different one.${reset}"
                 fi
                 break


### PR DESCRIPTION
This pull request changes the double brackets in the `container_shell_or_logs()` function. The issue with using double brackets is that they are not POSIX compliant and therefore unsupported by some shells. One example is the default `dash` (usually as `/bin/sh`) in for example the `hpb` pod of the TrueCharts Nextcloud app, which causes the function to throw an error when entering the Pod.

This shows the difference between single and double brackets on a POSIX shell without `[[` support:

```
$ [[ -e /bin/bash ]] && exec /bin/bash
sh: 2: [[: not found
$ [ -e /bin/bash ] && exec /bin/bash
www-data@nextcloud-7cbdc5c6bd-ns6gp:~/html$
```

As `[` is available on almost every system, this PR should not cause any negative side effects at all.