### PR TITLE
Restart image updates

### DIFF
--- a/functions/update_apps.sh
+++ b/functions/update_apps.sh
@@ -184,7 +184,7 @@ export -f pre_process
 
 restart_app(){
     dep_name=$(k3s kubectl -n ix-"$app" get deploy | sed -e '1d' -e 's/ .*//')
-    if k3s kubectl -n ix-"$app" rollout restart deploy dep_name; then
+    if k3s kubectl -n ix-"$app" rollout restart deploy "$dep_name"; then
         return 0
     else
         return 1

--- a/functions/update_apps.sh
+++ b/functions/update_apps.sh
@@ -158,11 +158,13 @@ pre_process(){
 
     # If rollbacks are enabled, or startstatus is stopped
     if [[ $rollback == "true" || "$startstatus"  ==  "STOPPED" ]]; then
-        # If app is external services, OR version is the same (container image update), skip post processing
+        # If app is external services, skip post processing
         if grep -qs "^$app_name,true" external_services; then 
             echo_array
             return
         elif [[ "$old_full_ver" == "$new_full_ver" ]]; then 
+            # restart the app if it was a container image update.
+            [[ "$verbose" == "true" ]] && echo_array+=("Restarting $app_name..")
             if ! restart_app; then
                 echo_array+=("Failed to restart $app_name")
             else

--- a/functions/update_apps.sh
+++ b/functions/update_apps.sh
@@ -185,8 +185,8 @@ export -f pre_process
 
 
 restart_app(){
-    dep_name=$(k3s kubectl -n ix-"$app" get deploy | sed -e '1d' -e 's/ .*//')
-    if k3s kubectl -n ix-"$app" rollout restart deploy "$dep_name"; then
+    dep_name=$(k3s kubectl -n ix-"$app_name" get deploy | sed -e '1d' -e 's/ .*//')
+    if k3s kubectl -n ix-"$app_name" rollout restart deploy "$dep_name"; then
         return 0
     else
         return 1


### PR DESCRIPTION
Restart Image Updates.

Reason: When applications receive an image update, they do not currently restart. Restarting is vital for applying these upgrades. 