### PR TITLE
Back port --self-update --major

### DIFF
--- a/functions/self_update.sh
+++ b/functions/self_update.sh
@@ -79,7 +79,7 @@ choose_branch() {
 
 update_func(){
 
-    if [[ "$include_major" == "true" ]] || is_major_update "v3.0.0" "v4.0.0"; then
+    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.0.0" "v4.0.0"; then
         echo "will update"
     else
         echo "will not update"

--- a/functions/self_update.sh
+++ b/functions/self_update.sh
@@ -78,11 +78,13 @@ choose_branch() {
 
 
 update_func(){
-    if [[ "$include_major" == "true" ]]; then
-        echo "On"
+
+    if [[ "$include_major" == "true" ]] || is_major_update "v3.0.0" "v4.0.0"; then
+        echo "will update"
     else
-        echo "Off"
+        echo "will not update"
     fi
+
 
     # Check if using a tag or branch
     if ! [[ "$hs_version" =~ v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then

--- a/functions/self_update.sh
+++ b/functions/self_update.sh
@@ -78,7 +78,11 @@ choose_branch() {
 
 
 update_func(){
-    echo "major: $include_major"
+    if [[ "$include_major" == "true" ]]; then
+        echo "On"
+    else
+        echo "Off"
+    fi
 
     # Check if using a tag or branch
     if ! [[ "$hs_version" =~ v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then

--- a/functions/self_update.sh
+++ b/functions/self_update.sh
@@ -80,11 +80,28 @@ choose_branch() {
 update_func(){
 
     if [[ "$include_major" == "true" ]] || ! is_major_update "v3.0.0" "v4.0.0"; then
-        echo "will update"
+        echo "will update v3.0.0 -> v4.0.0"
     else
-        echo "will not update"
+        echo "will not update v3.0.0 -> v4.0.0"
     fi
 
+    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.0.0" "v3.2.3"; then
+        echo "will update: v3.0.0 -> v3.2.3"
+    else
+        echo "will not update v3.0.0 -> v3.2.3"
+    fi
+
+    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.1.2" "v3.9.9"; then
+        echo "will update: v3.1.2 -> v3.9.9"
+    else
+        echo "will not update v3.1.2 -> v3.9.9"
+    fi
+
+    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.1.2" "v4.0.0"; then
+        echo "will update: v3.1.2 -> v4.0.0"
+    else
+        echo "will not update v3.1.2 -> v4.0.0"
+    fi
 
     # Check if using a tag or branch
     if ! [[ "$hs_version" =~ v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then

--- a/functions/self_update.sh
+++ b/functions/self_update.sh
@@ -78,31 +78,6 @@ choose_branch() {
 
 
 update_func(){
-
-    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.0.0" "v4.0.0"; then
-        echo "will update v3.0.0 -> v4.0.0"
-    else
-        echo "will not update v3.0.0 -> v4.0.0"
-    fi
-
-    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.0.0" "v3.2.3"; then
-        echo "will update: v3.0.0 -> v3.2.3"
-    else
-        echo "will not update v3.0.0 -> v3.2.3"
-    fi
-
-    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.1.2" "v3.9.9"; then
-        echo "will update: v3.1.2 -> v3.9.9"
-    else
-        echo "will not update v3.1.2 -> v3.9.9"
-    fi
-
-    if [[ "$include_major" == "true" ]] || ! is_major_update "v3.1.2" "v4.0.0"; then
-        echo "will update: v3.1.2 -> v4.0.0"
-    else
-        echo "will not update v3.1.2 -> v4.0.0"
-    fi
-
     # Check if using a tag or branch
     if ! [[ "$hs_version" =~ v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then
         # Check for updates on the main branch

--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -91,6 +91,9 @@ do
        restart-app)
                   restart_app=true
                   ;;
+             major)
+                  include_major=true
+                  ;;
                 *)
                   echo -e "Invalid Option \"--$OPTARG\"\n"
                   help


### PR DESCRIPTION
[Feature]
- Restrict major version updates with --self-update unless --major is specified

To prepare for the upcoming major update, I have modified the --self-update behavior. Now, updating to a new major HeavyScript version requires the explicit use of the --major flag.

The new CLI is under development and can be found on the "args" branch. It will remain there until it's fully developed and tested.