### PR TITLE
[New Feature] Automating generation of logs

### DIFF
--- a/functions/app/generate_app_logs.sh
+++ b/functions/app/generate_app_logs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+generate_app_logs_prompt(){
+    if [[ -z $1 ]]; then
+
+        # Get app name from user input
+        read -p "Enter app name: " APP_NAME
+     
+    else
+        APP_NAME="$1"
+    fi  
+    # Prepend 'ix-' to app name
+    APP_NAME="ix-$APP_NAME"
+
+    # Create logs directory with timestamp
+    TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+    LOGS_DIR="$APP_NAME-logs-$TIMESTAMP"
+    mkdir -p "$LOGS_DIR"
+
+    # Get list of pods in app and write to log file
+    LIST_FILE="$LOGS_DIR/list_of_pods.log"
+    k3s kubectl get pods -n $APP_NAME -o jsonpath='{.items[*].metadata.name}' > "$LIST_FILE"
+
+    # Loop through each pod and get its logs
+    for POD in $(cat "$LIST_FILE")
+    do
+    echo "Getting logs for pod $POD..."
+    LOG_FILE="$LOGS_DIR/$POD.log"
+    k3s kubectl logs -n $APP_NAME $POD > "$LOG_FILE" 2>&1 || echo "Error getting logs for pod $POD" >> "$LOG_FILE"
+    done
+}

--- a/functions/app/handler.sh
+++ b/functions/app/handler.sh
@@ -20,6 +20,9 @@ app_handler() {
         -h|--help)
             app_help
             ;;
+        -l|--logs)
+            generate_app_logs_prompt "${args[@]:1}"
+            ;;
         *)
             echo "Unknown app action: ${args[0]}"
             app_help


### PR DESCRIPTION
This feature lets you generate logs in a single command based on `app_name`. This speeds up the process that the user needs to submit when creating a support ticket on discord(where they can just dump this folder in the chat) and can be helpful when debugging a particular app. The logs are dumped in the present working dir. 

Currently it's only accesible through `heavy_script app --logs` or `heavy_script app -l`   where `app_name` as a cli argument is optional, I have not idea how to get it to work with your app selector menu which i think would be more user-friendly way, I leave that integrating part to you since I don't know much about this codebase.