### PR TITLE
Update PVC

### DIFF
--- a/functions/pvc/handler.sh
+++ b/functions/pvc/handler.sh
@@ -13,7 +13,7 @@ pvc_handler() {
     case "${args[0]}" in
         -m | --mount)
             # Call the function to mount the app
-            mount_app_func
+            mount_app_func "${args[@]:1}"
             ;;
         -u | --unmount)
             # Call the function to unmount the app

--- a/functions/pvc/handler.sh
+++ b/functions/pvc/handler.sh
@@ -15,9 +15,9 @@ pvc_handler() {
             # Call the function to mount the app
             mount_app_func "${args[@]:1}"
             ;;
-        -u | --unmount) "${args[@]:1}"
+        -u | --unmount) 
             # Call the function to unmount the app
-            unmount_app_func
+            unmount_app_func "${args[@]:1}"
             ;;
         -h | --help)
             # Call the function to display help for the pvc command

--- a/functions/pvc/handler.sh
+++ b/functions/pvc/handler.sh
@@ -15,7 +15,7 @@ pvc_handler() {
             # Call the function to mount the app
             mount_app_func "${args[@]:1}"
             ;;
-        -u | --unmount)
+        -u | --unmount) "${args[@]:1}"
             # Call the function to unmount the app
             unmount_app_func
             ;;

--- a/functions/pvc/help.sh
+++ b/functions/pvc/help.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 
-
 pvc_help() {
     echo -e "${bold}PVC Handler${reset}"
     echo -e "${bold}-----------${reset}"
-    echo -e "${blue}heavyscript pvc${reset} | [Option]"
+    echo -e "${blue}heavyscript pvc [Option] [APPNAME]${reset}"
     echo
     echo -e "${bold}Description${reset}"
     echo -e "${bold}-----------${reset}"
-    echo -e "Manage PVC-related actions with the PVC handler"
+    echo -e "Manage PVC-related actions such as mounting or unmounting PVCs. Specify an APPNAME to directly mount its PVCs or omit for a menu-driven experience."
     echo
     echo -e "${bold}Options${reset}"
     echo -e "${bold}-------${reset}"
-    echo -e "${blue}-m${reset}, ${blue}--mount${reset}"
-    echo -e "    Open a menu to mount PVCs."
-    echo -e "${blue}-u${reset}, ${blue}--unmount${reset}"
-    echo -e "    Unmount all mounted PVCs."
+    echo -e "${blue}-m${reset}, ${blue}--mount${reset} [APPNAME]"
+    echo -e "    Mount PVCs for a given app. If no APPNAME is provided, the user will be prompted to select one from the menu."
+    echo -e "${blue}-u${reset}, ${blue}--unmount${reset} [APPNAME]"
+    echo -e "    Unmount PVCs for a specific app. If no APPNAME is provided, all mounted PVCs will be unmounted."
     echo -e "${blue}-h${reset}, ${blue}--help${reset}"
     echo -e "    Display this help message."
     echo

--- a/functions/pvc/help.sh
+++ b/functions/pvc/help.sh
@@ -14,7 +14,8 @@ pvc_help() {
     echo -e "${blue}-m${reset}, ${blue}--mount${reset} [APPNAME]"
     echo -e "    Mount PVCs for a given app. If no APPNAME is provided, the user will be prompted to select one from the menu."
     echo -e "${blue}-u${reset}, ${blue}--unmount${reset} [APPNAME]"
-    echo -e "    Unmount PVCs for a specific app. If no APPNAME is provided, all mounted PVCs will be unmounted."
+    echo -e "    Unmount PVCs for a specific app. If no APPNAME is provided, the user will be prompted to select one from the menu."
+    echo -e "    Unmount all PVCs with ${blue}heavyscript pvc --unmount ALL${reset}"    
     echo -e "${blue}-h${reset}, ${blue}--help${reset}"
     echo -e "    Display this help message."
     echo

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -66,10 +66,6 @@ pvc_mount_pvc() {
     local data_name=$2
     local full_path=$3
 
-    # if [ ! -d "/mnt/mounted_pvc/$app" ]; then
-    #     mkdir "/mnt/mounted_pvc/$app"
-    # fi
-
     if ! zfs set mountpoint="/mounted_pvc/$app/$data_name" "$full_path"; then
         echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
         echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -11,6 +11,9 @@ pvc_retrieve_app_pool() {
 pvc_mount_all_in_namespace() {
     local app=$1
     local pvc_list
+    local pvc_names=()  # To store the names of PVCs for later output
+    local mount_status="Successfully Mounted"  # Assume success to start
+    local mount_point="/mnt/mounted_pvc/$app"
 
     mapfile -t pvc_list < <(k3s kubectl get pvc -n "ix-$app" | awk 'NR>1 {print $1}' | grep -v -- "-cnpg-main")
     
@@ -19,12 +22,26 @@ pvc_mount_all_in_namespace() {
 
         volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
         full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
+        
         if [ -n "$full_path" ]; then
-            pvc_mount_pvc "$app" "$data_name" "$full_path"
+            if ! pvc_mount_pvc "$app" "$data_name" "$full_path"; then
+                mount_status="Mount Failure for some volumes"  # Update status if there was a failure
+            else
+                pvc_names+=("$data_name")
+            fi
         else
             echo -e "${red}Error:${reset} Could not find a ZFS path for $data_name"
+            mount_status="Mount Failure for some volumes"
         fi
     done
+
+    # Now print the consolidated output
+    echo -e "${bold}PVC's:${reset}"
+    for pvc in "${pvc_names[@]}"; do
+        echo "           $pvc"
+    done
+    echo -e "${bold}Mounted To:${reset} $mount_point"
+    echo -e "${bold}Status:${reset} $mount_status"
 
     echo -e "\n${bold}To Unmount All at Once:${reset}"
     echo -e "${blue}heavyscript pvc --unmount${reset}\n"
@@ -66,15 +83,11 @@ pvc_mount_pvc() {
     local data_name=$2
     local full_path=$3
 
+    # Try to mount the PVC and return whether it was successful
     if ! zfs set mountpoint="/mounted_pvc/$app/$data_name" "$full_path"; then
-        echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
-        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"
+        return 1
     else
-        echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
-        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$app/$data_name${reset}"
-        echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
-        echo -e "${bold}To Unmount Manually:${reset}"
-        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$app/$data_name${reset}\n"
+        return 0
     fi
 }
 

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -39,7 +39,7 @@ pvc_mount_all_in_namespace() {
     mapfile -t pvc_list < <(k3s kubectl get pvc -n "ix-$app" | awk 'NR>1 {print $1}' | grep -v -- "-cnpg-main")
 
     
-    for data_name in $pvc_list; do
+    for data_name in "${pvc_list[@]}"; do
         local volume_name full_path
 
         volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
@@ -139,7 +139,7 @@ mount_app_func() {
     fi
 
     local data_name volume_name full_path
-    
+
     data_name=$(echo -e "$entire_line" | awk '{print $3}')
     volume_name=$(echo -e "$entire_line" | awk '{print $4}')
     full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "/$volume_name$")

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -26,18 +26,14 @@ pvc_mount_pvc() {
     fi
 
     if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
-        echo -e "\n${bold}──────────────────────────────────────────────${reset}"
         echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
-        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
-        echo -e "${bold}──────────────────────────────────────────────${reset}\n"
+        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"
     else
-        echo -e "\n${bold}──────────────────────────────────────────────${reset}"
         echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
         echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
         echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
         echo -e "${bold}To Unmount Manually:${reset}"
-        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
-        echo -e "${bold}──────────────────────────────────────────────${reset}\n"
+        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}\n"
     fi
 }
 

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-
 mount_app_func(){
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 
                    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-
-    # Use mapfile command to read the output of cli command into an array
-    mapfile -t pool_query < <(cli -m csv -c "storage pool query name,path" | sed -e '1d' -e '/^$/d')
 
     # Run the command and store the output in an array
     readarray -t output < <(k3s kubectl get pvc -A | sort -u | awk '{print $1 "\t" $2 "\t" $4}' | sed "s/^0/ /" | grep -v -- "-cnpg-main")
@@ -36,11 +32,12 @@ mount_app_func(){
                 fi
             fi
         done | column -t 
+
         echo 
         echo -e "0)  Exit"
         read -rt 120 -p "Please type a number: " selection || { echo -e "\n${red}Failed to make a selection in time${reset}" ; exit; }
 
-        #Check for valid selection. If no issues, continue
+        # Check for valid selection. If no issues, continue
         if [[ $selection == 0 ]]; then
             echo -e "Exiting.."
             exit
@@ -55,7 +52,7 @@ mount_app_func(){
 
         entire_line=$(echo -e "${output[selection]}")
 
-        #Stop applicaiton if not stopped
+        # Stop application if not stopped
         status=$(cli -m csv -c 'app chart_release query name,status' | 
                     grep "^$app," | 
                     awk -F ',' '{print $2}'| 
@@ -73,116 +70,31 @@ mount_app_func(){
         fi
         sleep 2
 
-        #Grab data then output and mount
+        # Grab data then output and mount
         data_name=$(echo -e "$entire_line" | awk '{print $3}')
         volume_name=$(echo -e "$entire_line" | awk '{print $4}')
         full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
 
-        # Loop until a valid selection is made
-        while true
-        do
-            clear -x
-            title
-            echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
-            echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
-            echo
-            echo -e "Available Pools:"
-
-            # Generate header
-            header="${blue}#\tPool\tPath\tAvailable Capacity${reset}"
-
-            # Generate rows
-            rows=()
-            i=0
-            for line in "${pool_query[@]}"; do
-                (( i++ ))
-                pool=$(echo -e "$line" | awk -F ',' '{print $1}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                path=$(echo -e "$line" | awk -F ',' '{print $2}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-                avail=$(
-                zfs list -p -o name,avail "$pool" \
-                | grep -o '[0-9]*$' \
-                | awk '{
-                    if ($1/1024/1024/1024/1024 >= 1)
-                        printf "%.2fTB", $1/1024/1024/1024/1024
-                    else
-                        printf "%.2fGB", $1/1024/1024/1024
-                }'
-                )
-                rows+=("$i)\t$pool\t$path\t$avail")
-            done
-
-            # Add an option for the boot directory
-            boot_num=$((i+1))
-            boot_avail=$(
-            zfs list -p -o name,avail boot-pool \
-            | grep -o '[0-9]*$' \
-            | awk '{
-                if ($1/1024/1024/1024/1024 >= 1)
-                    printf "%.2fTB", $1/1024/1024/1024/1024
-                else
-                    printf "%.2fGB", $1/1024/1024/1024
-            }'
-            )
-            rows+=("$boot_num)\tboot\t/mnt\t$boot_avail")
-
-            # Print output with header and rows formatted in columns
-            printf "%b\n" "$header" "${rows[@]}" | column -t -s $'\t'
-
-            # Ask user for input
-            echo
-            read -r -t 120 -p "Please select a pool by number: " pool_num || { echo -e "${red}Failed to make a selection in time${reset}" ; exit; }
-
-            # Check if the input is valid
-            if [[ $pool_num -ge 1 && $pool_num -le ${#rows[@]} ]]; then
-                selected_pool=$(echo -e "${rows[pool_num-1]}")
-                # Exit the loop
-                break
-            else
-                echo -e "${red}Invalid selection please try again${reset}" 
-                sleep 3
-            fi
-        done
-
-        # Assign the selected pool and path to variables
-        path=$(echo "$selected_pool" | awk -F '\t' '{print $3}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-        pool_name=$(echo "$selected_pool" | awk -F '\t' '{print $2}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-
         # Check if the folder "mounted_pvc" exists on the selected pool
-        if [ ! -d "$path/mounted_pvc" ]; then
+        if [ ! -d "/mnt/mounted_pvc" ]; then
             # If it doesn't exist, create it
-            mkdir "$path/mounted_pvc"
+            mkdir "/mnt/mounted_pvc"
         fi
 
         clear -x
         title
-        if  [[ $pool_name == "boot" ]]; then
-            # Mount the PVC to the selected dataset                    
-            if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path" ; then
-                mount_failure=true
-            fi
-            boot_mount=true
-        else
-            # Mount the PVC to the selected dataset                    
-            if ! zfs set mountpoint=/"$pool_name"/mounted_pvc/"$data_name" "$full_path" ; then
-                mount_failure=true
-            fi
-        fi
-
-        echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
-        echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
-        echo -e "${bold}Selected Pool:${reset} ${blue}$pool_name${reset}"
-        echo -e "${bold}Mounted To:${reset} ${blue}$path/mounted_pvc/$data_name${reset}"
-        if [[ $mount_failure != true ]]; then
-            echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
-        else
+        
+        # Mount the PVC to /mnt/mounted_pvc                    
+        if ! zfs set mountpoint=/mnt/mounted_pvc/"$data_name" "$full_path" ; then
             echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
-        fi
-        echo
-        if [[ $boot_mount == true ]]; then
-            echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
         else
-            echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/*/mounted_pvc/$data_name${reset}"
+            echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
+            echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
+            echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
+            echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
         fi
+        
+        echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
         echo
         echo -e "${bold}Or use the Unmount All option:${reset}"
         echo -e "${blue}heavyscript pvc --unmount${reset}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -35,7 +35,7 @@ pvc_mount_pvc() {
 pvc_mount_all_in_namespace() {
     local app=$1
 
-    local pvc_list=$(k3s kubectl get pvc -n "$app" | awk '{if(NR>1) print $1}')
+    local pvc_list=$(k3s kubectl get pvc -n "ix-photoprism" | awk '{if(NR>1) print $1}' | grep -v -- "-cnpg-main")
     
     for data_name in $pvc_list; do
         local volume_name=$(k3s kubectl get pvc "$data_name" -n "$app" -o=jsonpath='{.spec.volumeName}')

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -40,8 +40,10 @@ pvc_mount_all_in_namespace() {
 
     
     for data_name in $pvc_list; do
-        local volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
-        local full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
+        local volume_name full_path
+
+        volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
+        full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
         if [ -n "$full_path" ]; then
             pvc_mount_pvc "$data_name" "$full_path"
             echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
@@ -136,9 +138,11 @@ mount_app_func() {
         pvc_mount_all_in_namespace "$app"
     fi
 
-    local data_name=$(echo -e "$entire_line" | awk '{print $3}')
-    local volume_name=$(echo -e "$entire_line" | awk '{print $4}')
-    local full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "/$volume_name$")
+    local data_name volume_name full_path
+    
+    data_name=$(echo -e "$entire_line" | awk '{print $3}')
+    volume_name=$(echo -e "$entire_line" | awk '{print $4}')
+    full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "/$volume_name$")
 
 
     if [ ! -d "/mnt/mounted_pvc" ]; then

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -26,8 +26,7 @@ pvc_mount_all_in_namespace() {
         fi
     done
 
-    echo -e "${bold}──────────────────────────────────────────────${reset}"
-    echo -e "${bold}To Unmount All at Once:${reset}"
+    echo -e "\n${bold}To Unmount All at Once:${reset}"
     echo -e "${blue}heavyscript pvc --unmount${reset}\n"
 }
 
@@ -60,6 +59,27 @@ pvc_select_app() {
             echo -e "\n${red}Invalid Selection: ${blue}$selection${red}, was not an option${reset}"
         fi
     done
+}
+
+pvc_mount_pvc() {
+    local app=$1
+    local data_name=$2
+    local full_path=$3
+
+    if [ ! -d "/mnt/mounted_pvc/$app" ]; then
+        mkdir "/mnt/mounted_pvc/$app"
+    fi
+
+    if ! zfs set mountpoint="/mounted_pvc/$app/$data_name" "$full_path"; then
+        echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
+        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"
+    else
+        echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
+        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$app/$data_name${reset}"
+        echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
+        echo -e "${bold}To Unmount Manually:${reset}"
+        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$app/$data_name${reset}\n"
+    fi
 }
 
 pvc_stop_selected_app() {

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -134,35 +134,8 @@ mount_app_func() {
     pvc_stop_selected_app "$app"
     sleep 2
 
-    if [[ -n $manual_selection ]]; then
-        pvc_mount_all_in_namespace "$app"
-    fi
+    pvc_mount_all_in_namespace "$app"
 
-    local data_name volume_name full_path
-
-    data_name=$(echo -e "$entire_line" | awk '{print $3}')
-    volume_name=$(echo -e "$entire_line" | awk '{print $4}')
-    full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "/$volume_name$")
-
-
-    if [ ! -d "/mnt/mounted_pvc" ]; then
-        mkdir "/mnt/mounted_pvc"
-    fi
-
-    clear -x
-    title
-
-    if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
-        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
-    else
-        echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
-        echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
-        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
-        echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
-    fi
-
-    echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
-    echo -e "${bold}Or use the Unmount All option:${reset}\n${blue}heavyscript pvc --unmount${reset}"
 
     if [[ -z $manual_selection ]]; then
         while true; do

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -39,30 +39,24 @@ pvc_select_app() {
     title
 
     while true; do
-        # Display apps with numbers
         echo -e "\nSelect an App:"
         for i in "${!apps[@]}"; do
             echo "$((i+1))) ${apps[$i]}"
         done
         
-        # Provide option to exit
         echo -e "\n0) Exit\n"
 
-        # Get user input
         read -rp "Please type a number: " selection
 
-        # Exit if user selects 0
         if [[ "$selection" == "0" ]]; then
             echo "Exiting..."
             exit 0
         fi
 
-        # If user input is valid, echo the app name and break out of loop
         if [[ "$selection" -ge 1 && "$selection" -le "${#apps[@]}" ]]; then
             app="${apps[$((selection-1))]}"
             break
         else
-            # Display an error message for invalid selection
             echo -e "\n${red}Invalid Selection: ${blue}$selection${red}, was not an option${reset}"
         fi
     done
@@ -98,14 +92,14 @@ mount_app_func() {
     if [[ -z $manual_selection ]]; then
         pvc_select_app
     else
-        app=$manual_selection
-        #verify app is valid
+        app=${manual_selection,,}
         mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
-        if [[ ! " ${apps[*]} " =~ " ${app} " ]]; then
-            echo -e "${red}Error:${reset} $app is not a valid app"
+        if [[ ! " ${apps[*]} " =~ ${app} ]]; then
+            echo -e "${red}Error:${reset} $manual_selection is not a valid app"
             exit 1
         fi
     fi
+
 
     pvc_stop_selected_app "$app"
     sleep 2

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -142,7 +142,7 @@ mount_app_func() {
         app=${manual_selection,,}
         mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
         if [[ ! " ${apps[*]} " =~ ${app} ]]; then
-            echo -e "${red}Error:${reset} $manual_selection is not a valid app"
+            echo -e "${red}Error:${reset} $manual_selection does not exist in the list of applications"
             exit 1
         fi
     fi

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -18,19 +18,20 @@ pvc_format_output() {
 }
 
 pvc_mount_pvc() {
-    local data_name=$1
-    local full_path=$2
+    local app=$1
+    local data_name=$2
+    local full_path=$3
 
-    if [ ! -d "/mnt/mounted_pvc" ]; then
-        mkdir "/mnt/mounted_pvc"
+    if [ ! -d "/mnt/mounted_pvc/$app" ]; then
+        mkdir "/mnt/mounted_pvc/$app"
     fi
 
-    if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
+    if ! zfs set mountpoint=/mounted_pvc/"$data_name/$app" "$full_path"; then
         echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
         echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"
     else
         echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
-        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
+        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name/$app${reset}"
         echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
         echo -e "${bold}To Unmount Manually:${reset}"
         echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}\n"
@@ -49,7 +50,7 @@ pvc_mount_all_in_namespace() {
         volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
         full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
         if [ -n "$full_path" ]; then
-            pvc_mount_pvc "$data_name" "$full_path"
+            pvc_mount_pvc "$app" "$data_name" "$full_path"
         else
             echo -e "${red}Error:${reset} Could not find a ZFS path for $data_name"
         fi

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -50,6 +50,7 @@ pvc_mount_all_in_namespace() {
         echo -e "    $status_color${results[$i+1]}$reset: $blue${results[$i]}$reset"
     done
     echo -e "${bold}Mounted To:${reset} ${blue}$mount_point${reset}"
+    echo -e "\n${bold}unmount with: ${blue}heavyscript pvc --unmount $app${reset}"
 }
 
 pvc_select_app() {

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -138,12 +138,10 @@ mount_app_func() {
         fi
     fi
 
-
     pvc_stop_selected_app "$app"
     sleep 2
 
     pvc_mount_all_in_namespace "$app"
-
 
     if [[ -z $manual_selection ]]; then
         while true; do

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -111,7 +111,7 @@ pvc_stop_selected_app() {
     fi
 }
 
-pvc_mount_app() {
+mount_app_func() {
     local manual_selection=$1
 
     pvc_retrieve_app_pool

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -118,6 +118,15 @@ pvc_stop_selected_app() {
     fi
 }
 
+pvc_check_for_pvc(){
+    if k3s kubectl get pvc -n "ix-$app" --no-headers | grep -q .; then
+        return 0
+    else
+        echo -e "${yellow}$app, does not contain any PVC's${reset}"
+        exit 1
+    fi
+}
+
 #shellcheck disable=SC2120
 mount_app_func() {
     local manual_selection=$1
@@ -137,6 +146,8 @@ mount_app_func() {
             exit 1
         fi
     fi
+
+    pvc_check_for_pvc
 
     pvc_stop_selected_app "$app"
     sleep 2

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -1,107 +1,159 @@
 #!/bin/bash
 
-mount_app_func(){
+pvc_retrieve_app_pool() {
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 
                    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+}
 
-    # Run the command and store the output in an array
+pvc_format_output() {
     readarray -t output < <(k3s kubectl get pvc -A | sort -u | awk '{print $1 "\t" $2 "\t" $4}' | sed "s/^0/ /" | grep -v -- "-cnpg-main")
-
-    # Assign a number to each element of the array, except for the first one
-    count=0
+    
     for ((i=1; i<${#output[@]}; i++)); do
         output[i]="$((i))) ${output[i]}"
-        count=$((count+1))
+    done
+}
+
+pvc_mount_pvc() {
+    local data_name=$1
+    local full_path=$2
+
+    if [ ! -d "/mnt/mounted_pvc" ]; then
+        mkdir "/mnt/mounted_pvc"
+    fi
+
+    if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
+        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
+    else
+        echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
+        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
+        echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
+    fi
+}
+
+pvc_mount_all_in_namespace() {
+    local app=$1
+
+    local pvc_list=$(k3s kubectl get pvc -n "$app" | awk '{if(NR>1) print $1}')
+    
+    for data_name in $pvc_list; do
+        local volume_name=$(k3s kubectl get pvc "$data_name" -n "$app" -o=jsonpath='{.spec.volumeName}')
+        local full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
+        pvc_mount_pvc "$data_name" "$full_path"
     done
 
-    while true
-    do
-        clear -x
-        title
-        # Format the output for display
-        for ((i=0; i<${#output[@]}; i++)); do
-            if [[ $i -eq 0 ]]; then
-                echo -e "${blue}# ${output[i]}${reset}"
-            else
-                if [[ $((i % 2)) -eq 0 ]]; then
-                    echo -e "${gray}${output[i]}${reset}"
-                else
-                    echo -e "${output[i]}"
-                fi
-            fi
-        done | column -t 
+    echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
+    echo -e "${bold}Or use the Unmount All option:${reset}\n${blue}heavyscript pvc --unmount${reset}"
+}
 
+
+pvc_display_output() {
+    clear -x
+    title
+    for ((i=0; i<${#output[@]}; i++)); do
+        if [[ $i -eq 0 ]]; then
+            echo -e "${blue}# ${output[i]}${reset}"
+        else
+            if [[ $((i % 2)) -eq 0 ]]; then
+                echo -e "${gray}${output[i]}${reset}"
+            else
+                echo -e "${output[i]}"
+            fi
+        fi
+    done | column -t 
+}
+
+pvc_select_app() {
+    while true; do
+        pvc_display_output
+        
         echo 
         echo -e "0)  Exit"
         read -rt 120 -p "Please type a number: " selection || { echo -e "\n${red}Failed to make a selection in time${reset}" ; exit; }
 
-        # Check for valid selection. If no issues, continue
         if [[ $selection == 0 ]]; then
             echo -e "Exiting.."
             exit
         fi
+
         app=$(echo -e "${output[selection]}" | awk '{print $2}' | cut -c 4- )
 
         if [[ -z "$app" ]]; then
             echo -e "${red}Invalid Selection: ${blue}$selection${red}, was not an option${reset}"
             sleep 3
-            continue 
-        fi
-
-        entire_line=$(echo -e "${output[selection]}")
-
-        # Stop application if not stopped
-        status=$(cli -m csv -c 'app chart_release query name,status' | 
-                    grep "^$app," | 
-                    awk -F ',' '{print $2}'| 
-                    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-        if [[ "$status" != "STOPPED" ]]; then
-            echo -e "\nStopping ${blue}$app${reset} prior to mount"
-            stop_app "normal" "$app" "${timeout:-50}"
-            result=$(handle_stop_code "$?")
-            if [[ $? -eq 1 ]]; then
-                echo -e "${red}${result}${reset}"
-                exit 1
-            else
-                echo -e "${green}${result}${reset}"
-            fi
-        fi
-        sleep 2
-
-        # Grab data then output and mount
-        data_name=$(echo -e "$entire_line" | awk '{print $3}')
-        volume_name=$(echo -e "$entire_line" | awk '{print $4}')
-        full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
-
-        # Check if the folder "mounted_pvc" exists on the selected pool
-        if [ ! -d "/mnt/mounted_pvc" ]; then
-            # If it doesn't exist, create it
-            mkdir "/mnt/mounted_pvc"
-        fi
-
-        clear -x
-        title
-        
-        # Mount the PVC to /mnt/mounted_pvc                    
-        if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path" ; then
-            echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
         else
-            echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
-            echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
-            echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
-            echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
+            break
         fi
-        
-        echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
-        echo
-        echo -e "${bold}Or use the Unmount All option:${reset}"
-        echo -e "${blue}heavyscript pvc --unmount${reset}"
+    done
 
-        #Ask if user would like to mount something else
-        while true
-        do
+    entire_line="${output[selection]}"
+}
+
+pvc_stop_selected_app() {
+    local app=$1
+
+    status=$(cli -m csv -c 'app chart_release query name,status' | 
+             grep "^$app," | 
+             awk -F ',' '{print $2}'| 
+             sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+    if [[ "$status" != "STOPPED" ]]; then
+        echo -e "\nStopping ${blue}$app${reset} prior to mount"
+        stop_app "normal" "$app" "${timeout:-50}"
+        result=$(handle_stop_code "$?")
+        if [[ $? -eq 1 ]]; then
+            echo -e "${red}${result}${reset}"
+            exit 1
+        else
+            echo -e "${green}${result}${reset}"
+        fi
+    fi
+}
+
+pvc_mount_app() {
+    local manual_selection=$1
+
+    pvc_retrieve_app_pool
+
+    if [[ -z $manual_selection ]]; then
+        pvc_select_app
+    else
+        app=$manual_selection
+    fi
+
+    pvc_stop_selected_app "$app"
+    sleep 2
+
+    if [[ -n $manual_selection ]]; then
+        pvc_mount_all_in_namespace "$app"
+    fi
+
+    local data_name=$(echo -e "$entire_line" | awk '{print $3}')
+    local volume_name=$(echo -e "$entire_line" | awk '{print $4}')
+    local full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
+
+    if [ ! -d "/mnt/mounted_pvc" ]; then
+        mkdir "/mnt/mounted_pvc"
+    fi
+
+    clear -x
+    title
+
+    if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
+        echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
+    else
+        echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"
+        echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
+        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
+        echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
+    fi
+
+    echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
+    echo -e "${bold}Or use the Unmount All option:${reset}\n${blue}heavyscript pvc --unmount${reset}"
+
+    if [[ -z $manual_selection ]]; then
+        while true; do
             echo
             read -rt 120 -p "Would you like to mount anything else? (y/N): " yesno || { echo -e "\n${red}Failed to make a selection in time${reset}" ; exit; }
             case $yesno in
@@ -120,5 +172,5 @@ mount_app_func(){
                 ;;
             esac
         done
-    done
+    fi
 }

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -66,9 +66,9 @@ pvc_mount_pvc() {
     local data_name=$2
     local full_path=$3
 
-    if [ ! -d "/mnt/mounted_pvc/$app" ]; then
-        mkdir "/mnt/mounted_pvc/$app"
-    fi
+    # if [ ! -d "/mnt/mounted_pvc/$app" ]; then
+    #     mkdir "/mnt/mounted_pvc/$app"
+    # fi
 
     if ! zfs set mountpoint="/mounted_pvc/$app/$data_name" "$full_path"; then
         echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -17,7 +17,6 @@ pvc_format_output() {
     done
 }
 
-# Mounts the specified PVC.
 pvc_mount_pvc() {
     local data_name=$1
     local full_path=$2
@@ -26,39 +25,45 @@ pvc_mount_pvc() {
         mkdir "/mnt/mounted_pvc"
     fi
 
-    if ! zfs set mountpoint=/mnt/mounted_pvc/"$data_name" "$full_path"; then
+    if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path"; then
+        echo -e "\n${bold}──────────────────────────────────────────────${reset}"
+        echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
         echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
+        echo -e "${bold}──────────────────────────────────────────────${reset}\n"
     else
-        echo -e "${bold}Selected PVC:${reset} ${blue}$data_name${reset}"
+        echo -e "\n${bold}──────────────────────────────────────────────${reset}"
+        echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
         echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name${reset}"
         echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
+        echo -e "${bold}To Unmount Manually:${reset}"
+        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
+        echo -e "${bold}──────────────────────────────────────────────${reset}\n"
     fi
 }
 
-# Mounts all PVCs in the given namespace.
 pvc_mount_all_in_namespace() {
     local app=$1
     local pvc_list
 
     mapfile -t pvc_list < <(k3s kubectl get pvc -n "ix-$app" | awk 'NR>1 {print $1}' | grep -v -- "-cnpg-main")
-
+    
     for data_name in "${pvc_list[@]}"; do
         local volume_name full_path
 
         volume_name=$(k3s kubectl get pvc "$data_name" -n "ix-$app" -o=jsonpath='{.spec.volumeName}')
         full_path=$(zfs list -t filesystem -r "$ix_apps_pool/ix-applications/releases/$app/volumes" -o name -H | grep "$volume_name")
-        
         if [ -n "$full_path" ]; then
             pvc_mount_pvc "$data_name" "$full_path"
-            echo -e "${bold}Unmount Manually with:${reset}\n${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}"
         else
             echo -e "${red}Error:${reset} Could not find a ZFS path for $data_name"
         fi
     done
 
-    # Note: Moved this out of the loop as suggested.
-    echo -e "${bold}Or use the Unmount All option:${reset}\n${blue}heavyscript pvc --unmount${reset}"
+    echo -e "${bold}──────────────────────────────────────────────${reset}"
+    echo -e "${bold}To Unmount All at Once:${reset}"
+    echo -e "${blue}heavyscript pvc --unmount${reset}\n"
 }
+
 
 pvc_display_output() {
     clear -x

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -14,6 +14,8 @@ pvc_mount_all_in_namespace() {
     local results=()
     local mount_point="/mnt/mounted_pvc/$app"
 
+    clear -x
+    echo -e "${blue}Mounting PVC's for $app...${reset}"
     mapfile -t pvc_list < <(k3s kubectl get pvc -n "ix-$app" | awk 'NR>1 {print $1}' | grep -v -- "-cnpg-main")
     
     for data_name in "${pvc_list[@]}"; do
@@ -36,6 +38,9 @@ pvc_mount_all_in_namespace() {
         fi
         results+=("$data_name" "$status_color$status")
     done
+
+    clear -x
+    title
 
     # Now print the consolidated output
     echo -e "${bold}PVC's:${reset}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -119,7 +119,7 @@ pvc_stop_selected_app() {
 }
 
 pvc_check_for_pvc(){
-    if k3s kubectl get pvc -n "ix-$app" --no-headers | grep -q .; then
+    if k3s kubectl get pvc -n "ix-$app" --no-headers 2>/dev/null | grep -q .;then
         return 0
     else
         echo -e "${yellow}$app, does not contain any PVC's${reset}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -47,7 +47,7 @@ pvc_mount_all_in_namespace() {
     # Now print the consolidated output
     echo -e "${bold}PVC's:${reset}"
     for ((i=0; i<${#results[@]}; i+=2)); do
-        echo -e "    $status_color${results[$i+1]}$reset: $blue${results[$i]}$reset"
+        echo -e "    ${results[$i+1]}${results[$i+2]}$reset: $blue${results[$i]}$reset"
     done
     echo -e "${bold}Mounted to:${reset} ${blue}$mount_point${reset}"
     echo -e "${bold}Unmount with: ${blue}heavyscript pvc --unmount $app${reset}\n"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -47,7 +47,7 @@ pvc_mount_all_in_namespace() {
     # Now print the consolidated output
     echo -e "${bold}PVC's:${reset}"
     for ((i=0; i<${#results[@]}; i+=2)); do
-        echo -e "    ${results[$i+1]}${results[$i+2]}$reset: $blue${results[$i]}$reset"
+        echo -e "    ${results[$i+1]}$reset: $blue${results[$i]}$reset"
     done
     echo -e "${bold}Mounted to:${reset} ${blue}$mount_point${reset}"
     echo -e "${bold}Unmount with: ${blue}heavyscript pvc --unmount $app${reset}\n"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -2,6 +2,8 @@
 
 # Retrieves the application pool.
 pvc_retrieve_app_pool() {
+    clear -x
+    echo -e "${blue}Fetching application pool...${reset}"
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 
@@ -45,9 +47,9 @@ pvc_mount_all_in_namespace() {
     # Now print the consolidated output
     echo -e "${bold}PVC's:${reset}"
     for ((i=0; i<${#results[@]}; i+=2)); do
-        echo -e "           $status_color${results[$i+1]}$reset: $blue${results[$i]}$reset"
+        echo -e "    $status_color${results[$i+1]}$reset: $blue${results[$i]}$reset"
     done
-    echo -e "${bold}Mounted To:${reset} $mount_point"
+    echo -e "${bold}Mounted To:${reset} ${blue}$mount_point${reset}"
 }
 
 pvc_select_app() {
@@ -124,6 +126,8 @@ mount_app_func() {
     if [[ -z $manual_selection ]]; then
         pvc_select_app
     else
+        clear -x
+        echo -e "${blue}Validating App${reset}"
         app=${manual_selection,,}
         mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
         if [[ ! " ${apps[*]} " =~ ${app} ]]; then

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -32,7 +32,11 @@ pvc_mount_all_in_namespace() {
 }
 
 pvc_select_app() {
+    clear -x
+    echo -e "${blue}Fetching applications..${reset}"
     mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
+    clear -x
+    title
 
     while true; do
         # Display apps with numbers

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -85,7 +85,7 @@ mount_app_func(){
         title
         
         # Mount the PVC to /mnt/mounted_pvc                    
-        if ! zfs set mountpoint=/mnt/mounted_pvc/"$data_name" "$full_path" ; then
+        if ! zfs set mountpoint=/mounted_pvc/"$data_name" "$full_path" ; then
             echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}"
         else
             echo -e "${bold}Selected App:${reset} ${blue}$app${reset}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -49,8 +49,8 @@ pvc_mount_all_in_namespace() {
     for ((i=0; i<${#results[@]}; i+=2)); do
         echo -e "    $status_color${results[$i+1]}$reset: $blue${results[$i]}$reset"
     done
-    echo -e "${bold}Mounted To:${reset} ${blue}$mount_point${reset}"
-    echo -e "\n${bold}unmount with: ${blue}heavyscript pvc --unmount $app${reset}"
+    echo -e "${bold}Mounted to:${reset} ${blue}$mount_point${reset}"
+    echo -e "${bold}Unmount with: ${blue}heavyscript pvc --unmount $app${reset}\n"
 }
 
 pvc_select_app() {
@@ -128,7 +128,7 @@ mount_app_func() {
         pvc_select_app
     else
         clear -x
-        echo -e "${blue}Validating App${reset}"
+        echo -e "${blue}Validating app...${reset}"
         app=${manual_selection,,}
         mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
         if [[ ! " ${apps[*]} " =~ ${app} ]]; then

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -26,15 +26,15 @@ pvc_mount_pvc() {
         mkdir "/mnt/mounted_pvc/$app"
     fi
 
-    if ! zfs set mountpoint=/mounted_pvc/"$data_name/$app" "$full_path"; then
+    if ! zfs set mountpoint="/mounted_pvc/$app/$data_name" "$full_path"; then
         echo -e "${bold}PVC:${reset} ${red}$data_name${reset}"
         echo -e "${bold}Status:${reset} ${red}Mount Failure${reset}\n"
     else
         echo -e "${bold}PVC:${reset} ${blue}$data_name${reset}"
-        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$data_name/$app${reset}"
+        echo -e "${bold}Mounted To:${reset} ${blue}/mnt/mounted_pvc/$app/$data_name${reset}"
         echo -e "${bold}Status:${reset} ${green}Successfully Mounted${reset}"
         echo -e "${bold}To Unmount Manually:${reset}"
-        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$data_name${reset}\n"
+        echo -e "${blue}zfs set mountpoint=legacy \"$full_path\" && rmdir /mnt/mounted_pvc/$app/$data_name${reset}\n"
     fi
 }
 

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -57,10 +57,10 @@ pvc_select_app() {
     clear -x
     echo -e "${blue}Fetching applications..${reset}"
     mapfile -t apps < <(cli -m csv -c 'app chart_release query name' | tail -n +2 | sort | tr -d " \t\r" | awk 'NF')
-    clear -x
-    title
 
     while true; do
+        clear -x
+        title
         echo -e "\nSelect an App:"
         for i in "${!apps[@]}"; do
             echo "$((i+1))) ${apps[$i]}"

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -46,7 +46,7 @@ pvc_select_app() {
         done
         
         # Provide option to exit
-        echo -e "0) Exit\n"
+        echo -e "\n0) Exit\n"
 
         # Get user input
         read -rp "Please type a number: " selection

--- a/functions/pvc/mount.sh
+++ b/functions/pvc/mount.sh
@@ -118,6 +118,7 @@ pvc_stop_selected_app() {
     fi
 }
 
+#shellcheck disable=SC2120
 mount_app_func() {
     local manual_selection=$1
     app=""
@@ -152,6 +153,7 @@ mount_app_func() {
             [Yy] | [Yy][Ee][Ss])
                 clear -x
                 title
+                mount_app_func
                 break
                 ;;
             [Nn] | [Nn][Oo]|"")

--- a/functions/pvc/mount_menu.sh
+++ b/functions/pvc/mount_menu.sh
@@ -9,7 +9,7 @@ mount_prompt(){
         echo -e "${bold}PVC Mount Menu${reset}"
         echo -e "${bold}--------------${reset}"
         echo -e "1)  Mount"
-        echo -e "2)  Unmount All"
+        echo -e "2)  Unmount"
         echo
         echo -e "0)  Exit"
         read -rt 120 -p "Please type a number: " selection || { echo -e "\n${red}Failed to make a selection in time${reset}" ; exit; }

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -7,7 +7,7 @@ unmount_app_menu(){
     # Check if the mounted_apps array is empty
     if [[ -z ${mounted_apps[*]} ]]; then
         echo -e "${yellow}There are no PVCs to unmount.${reset}"
-        return
+        exit
     else
         while true; do
             # Display the menu

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -46,7 +46,9 @@ unmount_app_func(){
     apps=("$1")
 
     for i in "${!apps[@]}"; do
-        apps[i]="${apps[$i],,}"
+        if [[ "${apps[$i]}" != "ALL" ]]; then
+            apps[i]="${apps[$i],,}"
+        fi
     done
 
     ix_apps_pool=$(cli -c 'app kubernetes config' | 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -2,7 +2,7 @@
 
 unmount_app_menu(){
     # Use the find command to search for directories within /mnt/mounted_pvc/
-    mapfile -t mounted_apps < <(find /mnt/mounted_pvc/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+    mapfile -t mounted_apps < <(find /mnt/mounted_pvc/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null)
 
     # Check if the mounted_apps array is empty
     if [[ -z ${mounted_apps[*]} ]]; then
@@ -57,7 +57,7 @@ unmount_app_func(){
     unmount_array=()
 
     for app in "${apps[@]}"; do
-        mapfile -t unmount_array < <(find "/mnt/mounted_pvc/$app" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+        mapfile -t unmount_array < <(find "/mnt/mounted_pvc/$app" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null )
         
         # Check if the unmount_array is empty
         if [[ -z ${unmount_array[*]} ]]; then

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -51,6 +51,11 @@ unmount_app_func(){
         fi
     done
 
+    if [ ! -d "/mnt/mounted_pvc" ]; then
+        echo -e "${yellow}There is nothing to unmount${reset}"
+        exit 0
+    fi
+    
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -45,6 +45,10 @@ unmount_app_menu(){
 unmount_app_func(){
     apps=("$1")
 
+    for i in "${!apps[@]}"; do
+        apps[i]="${apps[$i],,}"
+    done
+
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -7,6 +7,7 @@ unmount_app_menu(){
     # Check if the mounted_apps array is empty
     if [[ -z ${mounted_apps[*]} ]]; then
         echo -e "${yellow}There are no PVCs to unmount.${reset}"
+        rmdir /mnt/mounted_pvc 2>/dev/null
         exit
     else
         while true; do
@@ -55,7 +56,7 @@ unmount_app_func(){
         echo -e "${yellow}There is nothing to unmount${reset}"
         exit 0
     fi
-    
+
     ix_apps_pool=$(cli -c 'app kubernetes config' | 
                    grep -E "pool\s\|" | 
                    awk -F '|' '{print $3}' | 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -66,7 +66,7 @@ unmount_app_func(){
         # Check if the unmount_array is empty
         if [[ -z ${unmount_array[*]} ]]; then
             echo -e "${yellow}$app's directory is empty, removing directory..${reset}"
-            rmdir "/mnt/$app/mounted_pvc" 2>/dev/null 
+            rmdir "/mnt/mounted_pvc/$app" 2>/dev/null 
             continue
         fi
 
@@ -84,7 +84,7 @@ unmount_app_func(){
             # Set the mountpoint to "legacy" and unmount
             if zfs set mountpoint=legacy "$full_path/$pvc"; then
                 echo -e "${blue}$pvc_name ${green}unmounted successfully.${reset}"
-                rmdir "/mnt/mounted_pvc/${app}${pvc_name}" 2>/dev/null
+                rmdir "/mnt/mounted_pvc/${app}/${pvc_name}" 2>/dev/null
             else
                 echo -e "${red}Failed to unmount ${blue}$pvc_name.${reset}"
                 echo -e "${yellow}Please make sure your terminal is not open in the mounted directory${reset}"

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -50,7 +50,9 @@ unmount_app_func(){
                    awk -F '|' '{print $3}' | 
                    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
-    if [[ -z $1 ]]; then
+    if [[ $1 == "ALL" ]]; then
+        mapfile -t apps < <(find /mnt/mounted_pvc/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null)
+    elif [[ -z $1 ]]; then
         unmount_app_menu
     fi
 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -78,7 +78,7 @@ unmount_app_func(){
                 {{end}}{{end}}")
 
             read -r app pvc_name pvc <<< "$main"
-            app=${app:3}
+
             full_path="$ix_apps_pool/ix-applications/releases/$app/volumes"
 
             # Set the mountpoint to "legacy" and unmount

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -59,8 +59,14 @@ unmount_app_func(){
     unmount_array=()
 
     for app in "${apps[@]}"; do
+        # Check if the directory exists
+        if [ ! -d "/mnt/mounted_pvc/$app" ]; then
+            echo -e "${red}Error:${reset} The directory '/mnt/mounted_pvc/$app' does not exist."
+            exit 1
+        fi
+
         mapfile -t unmount_array < <(find "/mnt/mounted_pvc/$app" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null )
-        
+
         # Check if the unmount_array is empty
         if [[ -z ${unmount_array[*]} ]]; then
             echo -e "${yellow}$app's directory is empty, removing directory..${reset}"

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -74,10 +74,10 @@ unmount_app_func(){
             # Get the PVC details
             main=$(k3s kubectl get pvc --all-namespaces \
                 --output="go-template={{range .items}}{{if eq .metadata.name \"$pvc_name\"}}\
-                {{.metadata.namespace}} {{.metadata.name}} {{.spec.volumeName}}{{\"\n\"}}\
+                {{.metadata.name}} {{.spec.volumeName}}{{\"\n\"}}\
                 {{end}}{{end}}")
 
-            read -r app pvc_name pvc <<< "$main"
+            read -r pvc_name pvc <<< "$main"
 
             full_path="$ix_apps_pool/ix-applications/releases/$app/volumes"
 

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -31,7 +31,7 @@ unmount_app_menu(){
                 return
             # Check if the selection is valid
             elif [[ $selection -ge 1 && $selection -le ${#mounted_apps[@]} ]]; then
-                app="${mounted_apps[$((selection-1))]}"
+                apps=("${mounted_apps[$((selection-1))]}")
                 return
             else
                 echo -e "${yellow}Invalid selection. Please try again.${reset}"

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -50,12 +50,8 @@ unmount_app_func(){
                    awk -F '|' '{print $3}' | 
                    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
-
-
     if [[ -z $1 ]]; then
         unmount_app_menu
-    else
-        pass
     fi
 
     unmount_array=()

--- a/functions/pvc/unmount.sh
+++ b/functions/pvc/unmount.sh
@@ -59,7 +59,7 @@ unmount_app_func(){
         app=$1
     fi
 
-    mapfile -t unmount_array < <(find "$pool_path/mounted_pvc/$app" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+    mapfile -t unmount_array < <(find "/mnt/mounted_pvc/$app" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 
     # Check if the unmount_array is empty
     if [[ -z ${unmount_array[*]} ]]; then

--- a/functions/update/post_process.sh
+++ b/functions/update/post_process.sh
@@ -78,7 +78,7 @@ post_process(){
                 echo_array+=("Became Active after $SECONDS seconds")
             fi
             if [[ "$startstatus"  ==  "STOPPED" ]]; then
-                update_stop_handler 'Returing to STOPPED state...'
+                update_stop_handler 'Returning to STOPPED state...'
             else
                 echo_array+=("Active")
             fi


### PR DESCRIPTION
[Features]
- Directly specify an application using `heavyscript app --mount/--unmount APPNAME`.
- Use `ALL` for unmounting all applications (not valid for `--mount`).

[Logic Updates]
- On command execution, all PVCs within a namespace will be mounted without individual selection, since the app remains inactive anyway.
- Refined unmounting: target a specific application or opt for `ALL` to unmount all.

[Examples]
heavyscript pvc --unmount photoprism
heavyscript pvc --unmount ALL
heavyscript pvc --mount photoprism

[Notes]
- Users can of course still see the menu if they decide not to pass an application name to --mount or --unmount or even pvc