### PR TITLE
Lifecycle - Unmount apps upon start

### DIFF
--- a/.default.config.ini
+++ b/.default.config.ini
@@ -65,3 +65,8 @@ enabled=true
 ## String options ##
 # File path for database dump folder
 dump_folder="./database_dumps"
+
+# Apps listed here will have their deployments shut down prior to their CNPG Database dump
+# This is usually uneccesary, and unless otherwise recommended, leave blank
+# Example: stop_before_dump=nextcloud,appname,appname
+stop_before_dump=""

--- a/functions/app/start_app.sh
+++ b/functions/app/start_app.sh
@@ -30,7 +30,7 @@ start_app_prompt() {
             exit
         fi
 
-        if [[ $replica_count == "null" ]]; then
+        if [[ $replica_count == "null" && $(check_filtered_apps "$app_name") == *"${app_name},official"* ]]; then
             echo -e "${blue}$app_name${red} cannot be started${reset}"
             echo -e "${yellow}Replica count is null${reset}"
             echo -e "${yellow}Looks like you found an application HS cannot handle${reset}"

--- a/functions/app/start_app.sh
+++ b/functions/app/start_app.sh
@@ -30,7 +30,7 @@ start_app_prompt() {
             exit
         fi
 
-        if [[ $replica_count == "null" && $(check_filtered_apps "$app_name") == *"${app_name},official"* ]]; then
+        if [[ $replica_count == "null" && $(check_filtered_apps "$app_name") != *"${app_name},official"* ]]; then
             echo -e "${blue}$app_name${red} cannot be started${reset}"
             echo -e "${yellow}Replica count is null${reset}"
             echo -e "${yellow}Looks like you found an application HS cannot handle${reset}"

--- a/functions/app/start_app.sh
+++ b/functions/app/start_app.sh
@@ -41,9 +41,8 @@ start_app_prompt() {
         echo -e "Starting ${blue}$app_name${reset}..."
 
         # Check if all cli commands were successful
-        if start_app "$app_name" "$replica_count"; then
+        if start_app "$app_name"; then
             echo -e "${blue}$app_name ${green}Started${reset}"
-            echo -e "${green}Replica count set to ${blue}$replica_count${reset}\n"
         else
             echo -e "${red}Failed to start ${blue}$app_name${reset}\n"
         fi

--- a/utils/check_filtered_apps.sh
+++ b/utils/check_filtered_apps.sh
@@ -12,6 +12,11 @@ check_filtered_apps() {
             else
                 empty
             end,
+            if .catalog == "TRUENAS" then
+                .name + ",official"
+            else
+                empty
+            end,
             if .config.cnpg.main.enabled == true then
                 .name + ",cnpg"
             else

--- a/utils/generate_config.sh
+++ b/utils/generate_config.sh
@@ -13,21 +13,11 @@ generate_config_ini() {
 add_database_options() {
     config_file="config.ini"
 
-    # Check if the [databases] section exists
-    if ! grep -q "^\[databases\]" "$config_file"; then
-        # Add the [databases] section to the config file
-        echo -e "\n[databases]" >> "$config_file"
-    fi
-
-    # Check if the enabled option exists
-    if ! grep -q "^enabled=" "$config_file"; then
-        # Add the enabled option with a default value and description
-        awk -i inplace -v enable_option="## true/false options ##\n# Enable or disable database dumps\nenabled=true\n" '/^\[databases\]/ { print; print enable_option; next }1' "$config_file"
-    fi
-
-    # Check if the dump_folder option exists
-    if ! grep -q "^dump_folder=" "$config_file"; then
-        # Add the dump_folder option with a default value and description
-        awk -i inplace -v dump_folder_option="\n## String options ##\n# File path for database dump folder\ndump_folder=\"./database_dumps\"" '/^enabled=true/ { print; print dump_folder_option; next }1' "$config_file"
+    # Check if the stop_before_dump option exists
+    if ! grep -q "^stop_before_dump=" "$config_file"; then
+        # Add the stop_before_dump option with a default value and description
+        awk -i inplace -v stop_before_dump_option="\n# Apps listed here will have their deployments shut down prior to their CNPG Database dump\n# This is usually unnecessary, and unless otherwise recommended, leave blank\n# Example: stop_before_dump=nextcloud,appname,appname\nstop_before_dump=\"\"\n" '/^dump_folder=.*/ { print; print stop_before_dump_option; next }1' "$config_file"
     fi
 }
+
+

--- a/utils/resources.sh
+++ b/utils/resources.sh
@@ -4,7 +4,7 @@ pull_replicas() {
     local app_name
     app_name="$1"
 
-    midclt call chart.release.get_instance "$app_name" | jq '.config.controller.replicas // .config.workload.main.replicas // .pod_status.desired'
+    midclt call chart.release.get_instance "$app_name" | jq '.config.controller.replicas // .config.workload.main.replicas'
 }
 
 restart_app(){

--- a/utils/start_app.sh
+++ b/utils/start_app.sh
@@ -52,7 +52,7 @@ get_running_job_id(){
 check_mounted(){
     local app_name=$1
 
-    if [[ -d /mnt/mounted_apps/"$app_name" ]]; then
+    if [[ -d /mnt/mounted_pvc/"$app_name" ]]; then
         unmount_app_func "$app_name" > /dev/null 2>&1
     fi
 }

--- a/utils/start_app.sh
+++ b/utils/start_app.sh
@@ -51,7 +51,6 @@ get_running_job_id(){
 
 start_app(){
     local app_name=$1
-    local replica_count=${2:-$(pull_replicas "$app_name")}
     local job_id
 
     # Check if app is a cnpg instance, or an operator instance
@@ -61,15 +60,15 @@ start_app(){
             return 1
         fi
         abort_job "$app_name"
-        job_id=$(midclt call chart.release.scale "$app_name" '{"replica_count": '"$replica_count"'}') || return 1
+        job_id=$(midclt call chart.release.redeploy "$app_name") || return 1
         wait_for_redeploy_methods "$app_name"
         midclt call core.job_abort "$job_id" > /dev/null 2>&1
     elif [[ $output == *"${app_name},stopAll-off"* ]]; then
-        job_id=$(midclt call chart.release.scale "$app_name" '{"replica_count": '"$replica_count"'}') || return 1
+        job_id=$(midclt call chart.release.redeploy "$app_name") || return 1
         wait_for_redeploy_methods "$app_name"
         midclt call core.job_abort "$job_id" > /dev/null 2>&1
     else
-        if ! cli -c 'app chart_release scale release_name='\""$app_name"\"\ 'scale_options={"replica_count": '"$replica_count}" > /dev/null 2>&1; then
+        if ! cli -c 'app chart_release redeploy release_name='\""$app_name"\" > /dev/null 2>&1; then
             return 1
         fi
     fi

--- a/utils/start_app.sh
+++ b/utils/start_app.sh
@@ -60,11 +60,11 @@ start_app(){
             return 1
         fi
         abort_job "$app_name"
-        job_id=$(midclt call chart.release.redeploy "$app_name") || return 1
+        job_id=$(midclt call chart.release.redeploy_internal "$app_name") || return 1
         wait_for_redeploy_methods "$app_name"
         midclt call core.job_abort "$job_id" > /dev/null 2>&1
     elif [[ $output == *"${app_name},stopAll-off"* ]]; then
-        job_id=$(midclt call chart.release.redeploy "$app_name") || return 1
+        job_id=$(midclt call chart.release.redeploy_internal "$app_name") || return 1
         wait_for_redeploy_methods "$app_name"
         midclt call core.job_abort "$job_id" > /dev/null 2>&1
     else

--- a/utils/start_app.sh
+++ b/utils/start_app.sh
@@ -49,9 +49,20 @@ get_running_job_id(){
         '.[] | select( .time_finished == null and .state == "RUNNING" and (.progress.description | test("Waiting for pods to be scaled to [0-9]+ replica\\(s\\)$")) and (.arguments[0] == $app_name and .method == "chart.release.scale") ) | .id'
 }
 
+check_mounted(){
+    local app_name=$1
+
+    if [[ -d /mnt/mounted_apps/"$app_name" ]]; then
+        unmount_app_func "$app_name" > /dev/null 2>&1
+    fi
+}
+
 start_app(){
     local app_name=$1
     local job_id
+
+    #check if app is currently mounted
+    check_mounted "$app_name"
 
     # Check if app is a cnpg instance, or an operator instance
     output=$(check_filtered_apps "$app_name")


### PR DESCRIPTION
[Features]
- Starting an app with HeavyScript will now unmount the app if it's mounted.
- CNPG database dumps no longer stop deployments by default, allowing for continuous operation.

[Refactor]
- The CNPG dump process has been refined to keep deployments running. 
- Opt-in to stop deployments during the dump using the `stop_before_dump` option in the `config.ini` file.
- Your config files should have automatically updated to have this new section.
