### PR TITLE
Enhanced Update Process with Improved Logging, Error Handling, and Success Criteria

### DIFF
--- a/functions/prune/prune.sh
+++ b/functions/prune/prune.sh
@@ -9,9 +9,9 @@ prune(){
                tr -d " \t\r\.")"
     if (( "$version" >= 2310 )); then
         if ! cli -c 'app container config prune prune_options={"remove_unused_images": true}' &>/dev/null ; then
-            echo -e "Failed to Prune Docker Images"
+            echo -e "Failed to Prune Images"
         else
-            echo -e "Pruned Docker Images"
+            echo -e "Pruned Images"
         fi
     elif (( "$version" >= 2212 )); then
         if ! cli -c 'app container config prune prune_options={"remove_unused_images": true, "remove_stopped_containers": true}' | head -n -4; then

--- a/functions/update/pre_process.sh
+++ b/functions/update/pre_process.sh
@@ -45,7 +45,6 @@ update_app_function() {
     # Send app through update function
     [[ "$verbose" == true ]] && echo_array+=("Updating..")
     if ! update_app; then
-        echo_array+=("Failed to update\nManual intervention may be required")
         return 1
     else
         if [[ $old_full_ver == "$new_full_ver" ]]; then

--- a/functions/update/pre_process.sh
+++ b/functions/update/pre_process.sh
@@ -141,7 +141,7 @@ pre_process() {
         fi
 
         if [[ "$old_full_ver" == "$new_full_ver" ]]; then 
-            image_update_restart
+            # image_update_restart disable for now, as it is most likely no longer needed.
             echo_array
             return
         fi

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -73,7 +73,7 @@ process_update() {
             continue
         elif [[ $output =~ "dump interrupted" ]]; then
             if $final_check; then
-                echo_array+=("Failed to update. Manual intervention may be required.")
+                echo_array+=("Failed to update.")
                 echo_array+=("Middlewared is overloaded. Consider lowering concurrent updates.")
             else
                 sleep 10

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -68,6 +68,7 @@ process_update() {
         elif [[ $? == 124 ]]; then
             if $final_check; then
                 echo_array+=("Update process timed out after ${timeout:-300} seconds.")
+                echo_array+=("Consider raising the timeout value.")
             fi
             return 1
         elif [[ $output =~ "No update is available" ]]; then
@@ -75,7 +76,7 @@ process_update() {
         elif [[ $output =~ "cannot create snapshot" ]]; then
             if [[ "$output" == "$last_snapshot_error" ]]; then
                 if $final_check; then
-                    echo_array+=("Repeated failure to remove the same snapshot: $output")
+                    echo_array+=("Repeated failure to remove the snapshot preventing updates: $output")
                 fi
                 return 1
             else

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -65,6 +65,11 @@ process_update() {
     while true; do
         if output=$(timeout 300s cli -c 'app chart_release upgrade release_name=''"'"$app_name"'"' 2>&1); then
             return 0
+        elif [[ $? == 124 ]]; then
+            if $final_check; then
+                echo_array+=("Update process timed out after 300 seconds.")
+            fi
+            return 1
         elif [[ $output =~ "No update is available" ]]; then
             return 0
         elif [[ $output =~ "cannot create snapshot" ]]; then

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -70,6 +70,9 @@ process_update() {
             handle_snapshot_error "$output"
             handled_snapshot_error=true
             continue
+        elif [[ $output =~ "dump interrupted" ]]; then
+            sleep 20
+            continue
         else
             if $last_attempt; then
                 echo_array+=("Failed to update\nManual intervention may be required")

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -72,7 +72,7 @@ process_update() {
             continue
         elif [[ $output =~ "dump interrupted" ]]; then
             sleep 20
-            continue
+            return 1
         else
             if $last_attempt; then
                 echo_array+=("Failed to update\nManual intervention may be required")

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -63,11 +63,11 @@ process_update() {
     local last_snapshot_error=""
 
     while true; do
-        if output=$(timeout 300s cli -c 'app chart_release upgrade release_name=''"'"$app_name"'"' 2>&1); then
+        if output=$(timeout "${timeout:-300}"s cli -c 'app chart_release upgrade release_name=''"'"$app_name"'"' 2>&1); then
             return 0
         elif [[ $? == 124 ]]; then
             if $final_check; then
-                echo_array+=("Update process timed out after 300 seconds.")
+                echo_array+=("Update process timed out after ${timeout:-300} seconds.")
             fi
             return 1
         elif [[ $output =~ "No update is available" ]]; then

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -76,8 +76,8 @@ process_update() {
 }
 
 update_app() {
-    local before_loop
-
+    local before_loop update_avail count
+    
     while true; do
         # Function to check update availability
         check_update_avail() {

--- a/functions/update/utils.sh
+++ b/functions/update/utils.sh
@@ -82,7 +82,7 @@ process_update() {
         else
             error_message=$(echo "$output" | grep -Ev '^\[[0-9]+%\]')
             local message_trimmed=false
-            local additional_message="To see the full error, go to TrueNAS SCALE GUI, and look at the Jobs icon. Click your failed jobs to see the full message."
+            local additional_message="For full error details, visit TrueNAS SCALE GUI: Check the Jobs icon and select your failed job."
             local additional_message_length=${#additional_message}
 
             if ! $verbose && ((${#error_message} > max_error_length + additional_message_length)); then

--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -90,7 +90,7 @@ if remove_no_config_args; then
 fi
 
 # Run the self update function if the script has not already been updated
-if [[ $no_self_update == false ]]; then
+if [[ $no_self_update == false ]] && ! check_help "${args[@]}"; then
     self_update_handler "${args[@]}"
 fi
 

--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -90,7 +90,7 @@ if remove_no_config_args; then
 fi
 
 # Run the self update function if the script has not already been updated
-if [[ $no_self_update == false ]] && ! check_help "${args[@]}"; then
+if [[ $no_self_update == false ]] && check_help "${args[@]}"; then
     self_update_handler "${args[@]}"
 fi
 


### PR DESCRIPTION
[Features]
- Add logs to update failures
- - Full logs for --verbose
- - Logs limited to 500 characters for non-verbose

[Improvements]
- Attempt fix towards updates reporting they failed, when they have not
- - Specifically handle middlewared timeouts, which is usually the cause of these false reports

- Print better error messages for updating, such as:
- - If the command itself times out, say so, and recommend a higher --timeout
- - If middlewared consistently times out, recommend a lower number of concurrent updates
- -  If snapshots preventing updates are not being deleted, state that
- - Otherwise print out an error for the user

- If the update command returns that there is no update available, report that as a successful update

[Other]
- Remove restart container logic after updating container images
- Do not self update if -h or --help is called, in any context.
- Change "Removed Docker Images" to just "Removed Images".