### PR TITLE
Revert self-update breaking change 

### DIFF
--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -90,7 +90,7 @@ if remove_no_config_args; then
 fi
 
 # Run the self update function if the script has not already been updated
-if [[ $no_self_update == false ]] && check_help "${args[@]}"; then
+if [[ $no_self_update == false ]]; then
     self_update_handler "${args[@]}"
 fi
 


### PR DESCRIPTION
[Bugfix]
- v2.8.0 broke self update, this PR reverts the change.

[Instructions]
Users already on v2.8.0 will have to do the following:
1. Open a shell 
2. Enter the Heavyscript menu: 
- - heavyscript
or
- - Go to where heavyscript is installed and run: 
- - bash heavy_script/heavy_script.sh

4. Choose option 4: Heavyscript Options
5. Choose option 1: Self Update
