### PR TITLE
Fix link errors

### DIFF
--- a/functions/deploy.sh
+++ b/functions/deploy.sh
@@ -38,6 +38,48 @@ update_repo() {
     fi
 }
 
+ensure_sudoers() {
+    local  env_keep_exists secure_path_exists TMP_FILE
+    local  user="$1"
+    local  user_bin_dir="$2/bin"
+
+    # Check if specific entries already exist in the sudoers file
+    env_keep_exists=$(grep -c "Defaults:$user env_keep+=\"PATH\"" /etc/sudoers)
+    secure_path_exists=$(grep -c "Defaults:$user secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$user_bin_dir\"" /etc/sudoers)
+
+    # Exit the function if no changes are needed
+    if [[ $env_keep_exists -gt 0 && $secure_path_exists -gt 0 ]]; then
+        return 0
+    fi
+
+    # Create a temporary file only if changes are needed
+    TMP_FILE=$(mktemp)
+    
+    # Ensure cleanup on exit
+    trap 'rm -f "$TMP_FILE"' EXIT
+
+    # Copy current sudoers to temp
+    cat /etc/sudoers > "$TMP_FILE"
+
+    # Append new lines only if they don't already exist
+    if [[ $env_keep_exists -eq 0 ]]; then
+        echo "Defaults:$user env_keep+=\"PATH\"" >> "$TMP_FILE"
+    fi
+
+    if [[ $secure_path_exists -eq 0 ]]; then
+        echo "Defaults:$user secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$user_bin_dir\"" >> "$TMP_FILE"
+    fi
+
+    # Check for syntax errors with visudo
+    if visudo -c -f "$TMP_FILE"; then
+        # If the temp file is okay, safely copy it to the actual sudoers file
+        sudo cp "$TMP_FILE" /etc/sudoers
+        echo -e "${green}Sudoers file has been updated successfully.${reset}\n"
+    else
+        echo -e "${red}Error found in sudoers temp file. No changes were made.${reset}"
+    fi
+}
+
 # colors
 reset='\033[0m'
 red='\033[0;31m'
@@ -50,8 +92,8 @@ USER_HOME=$(get_user_home)
 script_name='heavyscript'
 script_dir="$USER_HOME/heavy_script"
 user_bin_dir="$USER_HOME/bin"
-system_bin_dir="/usr/local/bin"
 user_script_wrapper="$user_bin_dir/$script_name"
+invoking_user=$(get_invoking_user)
 
 main() {
     # Check if user has a home
@@ -60,12 +102,6 @@ main() {
         echo -e "${red}Please create a home directory for the user.${reset}" >&2
         echo -e "${red}You can do so under the credentials tab in the Truenas SCALE GUI${reset}" >&2
         exit 1
-    fi
-
-    if [[ $EUID -ne 0 ]]; then
-        echo -e "${yellow}Warning: The script is not running with root privileges. To create a symlink in ${blue}$system_bin_dir${yellow}, please rerun the script with sudo or as the root user.${reset}"
-        echo -e "${yellow}You can exit now with CTRL+C to rerun with sudo, or wait 10 seconds to continue without creating the system-wide symlink.${reset}"
-        sleep 10
     fi
 
     # Check if the script repository already exists
@@ -117,13 +153,19 @@ main() {
         mkdir "$user_bin_dir"
     fi
 
-
     # Create symlink inside user's bin only
     echo -e "${blue}Creating $user_script_wrapper wrapper...${reset}"
     ln -sf "$script_dir/bin/$script_name" "$user_script_wrapper"
     chmod +x "$script_dir/bin/$script_name"
 
 
+    echo
+
+    if [[ $EUID -eq 0 && -n $SUDO_USER ]]; then
+        echo -e "${blue}Adding $invoking_user and $USER_HOME to sudoers...${reset}"
+        ensure_sudoers "$invoking_user" "$USER_HOME"
+    fi
+    
     echo
 
     # Add $USER_HOME/bin to PATH in .bashrc and .zshrc
@@ -133,21 +175,12 @@ main() {
             touch "$USER_HOME/$rc_file"
         fi
 
-        if [[ $USER_HOME != "/root" ]]; then
-            if ! grep -q "$user_bin_dir" "/root/$rc_file"; then
-                echo -e "${blue}Adding $user_bin_dir to /root/$rc_file...${reset}"
-                echo "export PATH=$user_bin_dir:\$PATH" >> "/root/$rc_file"
-            fi
-        fi
-
         if ! grep -q "$user_bin_dir" "$USER_HOME/$rc_file"; then
             echo -e "${blue}Adding $user_bin_dir to $USER_HOME/$rc_file...${reset}"
             echo "export PATH=$user_bin_dir:\$PATH" >> "$USER_HOME/$rc_file"
         fi
     done
 
-    local invoking_user
-    invoking_user=$(get_invoking_user)
     if [[ $EUID -eq 0 && -n $SUDO_USER ]]; then
         echo -e "${green}Changing ownership of HeavyScript to ${blue}$invoking_user${green}...${reset}"
         chown -R "$invoking_user" "$script_dir"

--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -48,14 +48,11 @@ while IFS= read -r script_file; do
     source "$script_file"
 done < <(find functions utils -name "*.sh" -exec printf '%s\n' {} \;)
 
-# Ensure symlink within /usr/local/bin is active, for when the script is run with sudo
-ensure_symlink
+# Ensure sudoers file contains the necessary configuration
+ensure_sudoers
 
 # generate the config.ini file if it does not exist
 generate_config_ini
-
-# remove the [DNS] section from the config.ini file if it exists
-remove_dns_section
 
 # Separate bundled short options
 args=()

--- a/heavy_script.sh
+++ b/heavy_script.sh
@@ -49,7 +49,9 @@ while IFS= read -r script_file; do
 done < <(find functions utils -name "*.sh" -exec printf '%s\n' {} \;)
 
 # Ensure sudoers file contains the necessary configuration
-ensure_sudoers
+if [[ $EUID -eq 0 ]]; then
+    ensure_sudoers
+fi
 
 # generate the config.ini file if it does not exist
 generate_config_ini

--- a/utils/generate_config.sh
+++ b/utils/generate_config.sh
@@ -9,13 +9,3 @@ generate_config_ini() {
         sleep 5
     fi
 }
-
-remove_dns_section() {
-    local config_file="config.ini"
-
-    # Check if the [DNS] section exists in the config.ini file
-    if grep -q "^\[DNS\]" "$config_file"; then
-        # Remove the [DNS] section from the config.ini file
-        awk '/^\[DNS\]/ {flag=1; next} /^\[SELFUPDATE\]/ {flag=0} !flag' "$config_file" > temp.ini && mv temp.ini "$config_file"
-    fi
-}

--- a/utils/permissions.sh
+++ b/utils/permissions.sh
@@ -63,7 +63,6 @@ ensure_sudoers() {
 
     # Exit the function if no changes are needed
     if [[ $env_keep_exists -gt 0 && $secure_path_exists -gt 0 ]]; then
-        echo "No updates needed for sudoers file."
         return 0
     fi
 

--- a/utils/permissions.sh
+++ b/utils/permissions.sh
@@ -17,13 +17,63 @@ check_root() {
     fi
 }
 
-ensure_symlink() {
-    local script_location="$script_path/bin/heavyscript"
+ensure_sudoers() {
+    get_invoking_user() {
+        if [[ $EUID -eq 0 ]]; then
+            echo "${SUDO_USER:-root}"
+        else
+            whoami
+        fi
+    }
 
-    if ! grep -q "$script_location" "/root/$rc_file"; then
-        echo -e "${blue}Adding $script_location to /root/$rc_file...${reset}"
-        echo "export PATH=$script_location:\$PATH" >> "/root/$rc_file"
+    local user env_keep_exists secure_path_exists TMP_FILE
+
+    local script_location="$script_path/bin/heavyscript"
+    user=$(get_invoking_user)
+
+    # No need to modify sudoers if the script is run as root
+    if [[ $user == "root" ]]; then
+        return 0
+    fi
+
+    # Check if specific entries already exist in the sudoers file
+    env_keep_exists=$(grep -c "Defaults:$user env_keep+=\"PATH\"" /etc/sudoers)
+    secure_path_exists=$(grep -c "Defaults:$user secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$script_location\"" /etc/sudoers)
+
+    # Exit the function if no changes are needed
+    if [[ $env_keep_exists -gt 0 && $secure_path_exists -gt 0 ]]; then
+        echo "No updates needed for sudoers file."
+        return 0
+    fi
+
+    # Create a temporary file only if changes are needed
+    TMP_FILE=$(mktemp)
+    
+    # Ensure cleanup on exit
+    trap 'rm -f "$TMP_FILE"' EXIT
+
+    # Copy current sudoers to temp
+    cat /etc/sudoers > "$TMP_FILE"
+
+    # Append new lines only if they don't already exist
+    if [[ $env_keep_exists -eq 0 ]]; then
+        echo "Defaults:$user env_keep+=\"PATH\"" >> "$TMP_FILE"
+    fi
+
+    if [[ $secure_path_exists -eq 0 ]]; then
+        echo "Defaults:$user secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$script_location\"" >> "$TMP_FILE"
+    fi
+
+    # Check for syntax errors with visudo
+    if visudo -c -f "$TMP_FILE"; then
+        # If the temp file is okay, safely copy it to the actual sudoers file
+        sudo cp "$TMP_FILE" /etc/sudoers
+        echo "Sudoers file has been updated successfully."
+    else
+        echo "Error found in sudoers temp file. No changes were made."
     fi
 }
+
+
 
 

--- a/utils/permissions.sh
+++ b/utils/permissions.sh
@@ -37,7 +37,7 @@ ensure_sudoers() {
     IFS='|' read -r user home <<< "$output"
 
     # No need to modify sudoers if the script is run as root
-    if [[ $user == "root" || $home == "/root" || $script_path == "/root/heavy_script" ]]; then
+    if [[ $user == "root" || $home == "/root" || $script_path == "/root/heavy_script" || -z $home || -z $user ]]; then
         return 0
     fi
 

--- a/utils/permissions.sh
+++ b/utils/permissions.sh
@@ -18,21 +18,12 @@ check_root() {
 }
 
 ensure_symlink() {
-    local system_script_wrapper="/usr/local/bin/heavyscript"
     local script_location="$script_path/bin/heavyscript"
 
-    if [[ ! -L "$system_script_wrapper" || ! -e "$system_script_wrapper" ]]; then
-        echo "Warning: Symlink from $script_location to $system_script_wrapper is broken."
-
-        if [[ $EUID -eq 0 ]]; then
-            echo -e "Restoring symlink in $system_script_wrapper...\n"
-            ln -sf "$script_location" "$system_script_wrapper"
-            chmod +x "$script_location"
-        else
-            echo "Warning: The script is not running as root. To restore the symlink, run the script with sudo using the following command:"
-            echo "sudo bash $script"
-            echo "or run the script as the root user."
-            sleep 5
-        fi
+    if ! grep -q "$script_location" "/root/$rc_file"; then
+        echo -e "${blue}Adding $script_location to /root/$rc_file...${reset}"
+        echo "export PATH=$script_location:\$PATH" >> "/root/$rc_file"
     fi
 }
+
+

--- a/utils/permissions.sh
+++ b/utils/permissions.sh
@@ -18,32 +18,23 @@ check_root() {
 }
 
 ensure_sudoers() {
-    get_invoking_user() {
-        if [[ $EUID -eq 0 ]]; then
-            echo "${SUDO_USER:-root}"
-        else
-            whoami
-        fi
+    find_user_and_home() {
+        local script_path="$1"
+        while IFS=: read -r username _ _ _ _ home _; do
+            if [[ "$script_path" == "$home"* ]]; then
+                echo "$username|$home"
+                return 0
+            fi
+        done < <(getent passwd | grep -Ev "nonexistent|nologin$")
     }
-
-    get_user_home() {
-        local user_home
-
-        if [[ $EUID -eq 0 ]]; then  # Script is running as root
-            # Use SUDO_USER if set, otherwise fall back to root's home
-            user_home=$(getent passwd "${SUDO_USER:-root}" | cut -d: -f6)
-        else  # Script is run by a regular user
-            user_home=$HOME
-        fi
-
-        echo "$user_home"
-    }
-
-
+    
     local user env_keep_exists secure_path_exists TMP_FILE home
 
-    user=$(get_invoking_user)
-    home=$(get_user_home)
+    # Capture output, which contains both user and home
+    output=$(find_user_and_home "$script_path")
+
+    # Split output into user and home
+    IFS='|' read -r user home <<< "$output"
 
     # No need to modify sudoers if the script is run as root
     if [[ $user == "root" || $home == "/root" || $script_path == "/root/heavy_script" ]]; then


### PR DESCRIPTION
Resolves #160

Due to recent policy changes in Dragonfish, modifications to certain files and directories have been restricted. This has necessitated a rethink in how we manage the visibility of paths between the user invoking sudo and the sudo environment itself.

This update renames the `ensure_symlink` function to `ensure_sudoers` and modifies its functionality to better align with the new restrictions. Now, instead of creating symlinks, the function appends two lines to the sudoers file. These lines ensure that the `PATH` for users invoking sudo includes `$HOME/bin`, making it visible and accessible within the sudo environment.

Changes:
- Renamed `ensure_symlink` to `ensure_sudoers`.
- Modified function to append `$HOME/bin` to the sudoer's `PATH`.

This adjustment simplifies the configuration and enhances compliance with the updated Dragonfish policies.
